### PR TITLE
preinstall script made cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "extension-create": "cross-env NODE_ENV=development node cli.js",
     "lint": "eslint --config=eslintrc.json",
-    "preinstall": "sh preinstall.sh",
+    "preinstall": "cd create && yarn install && cd .. && cd develop && yarn install && cd ..",
     "deploy": "np",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "develop",
     "cli.js",
     "messages.js",
-    "preinstall.sh",
     "reservedKeywords.js"
   ],
   "dependencies": {

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -1,2 +1,0 @@
-cd create && yarn install && cd ..
-cd develop && yarn install && cd ..


### PR DESCRIPTION
Removed UNIX-only executable
The content of that executable was moved into preinstall script itself.
This way the installation flow was made cross-platform. Please note that I did not test it on UNIX based machine. 