### PR TITLE
Fix: correctly allow /* as pathname in matches

### DIFF
--- a/programs/develop/webpack/plugin-extension/feature-web-resources/web-resources-lib/resolve-war.ts
+++ b/programs/develop/webpack/plugin-extension/feature-web-resources/web-resources-lib/resolve-war.ts
@@ -74,7 +74,7 @@ function isValidChromeMatchPattern(pattern: string): boolean {
 
   try {
     const u = new URL(parseable)
-    return u.pathname === '/'
+    return u.pathname === '/*'
   } catch {
     return false
   }


### PR DESCRIPTION
See the comments in the code snippet below for an explanation of the bug:

```ts
function isValidChromeMatchPattern(pattern: string): boolean {
  if (pattern === '<all_urls>') return true
  if (/[?#]/.test(pattern)) return false
  if (!pattern.endsWith('/*')) return false // 1. Requires that the pathname in matches be `/*`
  const parseable = pattern.replace(/^\*:\/\//, 'https://')

  try {
    const u = new URL(parseable)
    return u.pathname === '/' // 2. This always fails due to #1
  } catch {
    return false
  }
```