### PR TITLE
Added -b shortcut to browser option, fixes #429

### DIFF
--- a/programs/cli/commands/dev.ts
+++ b/programs/cli/commands/dev.ts
@@ -87,7 +87,7 @@ export function registerDevCommand(program: Command, telemetry: any) {
       'what path to use for the browser profile. A boolean value of false sets the profile to the default user profile. Defaults to a fresh profile'
     )
     .option(
-      '--browser <chrome | chromium | edge | firefox | chromium-based | gecko-based | firefox-based>',
+      '-b, --browser <chrome | chromium | edge | firefox | chromium-based | gecko-based | firefox-based>',
       'specify a browser/engine to run. Defaults to `chromium`'
     )
     .option(


### PR DESCRIPTION
## Summary

The documentation includes a -b shortcut for the --browser command-line option for `extension dev`. 

## Changes

I added -b to the --browser option declaration, basd on the commander documentation:

https://github.com/tj/commander.js?tab=readme-ov-file#options

## Test plan

- [ ] Automated tests updated or not needed
- [ ] Manual testing completed
- [ x] Docs updated or not needed

## Related links

- Issue: #429 

